### PR TITLE
Updated and corrected Salesforce as Produsent and included SaaS-Proxy.

### DIFF
--- a/produsenter.yaml
+++ b/produsenter.yaml
@@ -132,7 +132,9 @@ arbeidsgiver-dialog:
   bruksvilkårGodkjent: 2023-02-14
   accessPolicy:
     - dev-gcp:teamcrm:saas-proxy
+    - dev-external:teamcrm:salesforce
     - prod-gcp:teamcrm:saas-proxy
+    - prod-external:teamcrm:salesforce
   merkelapper:
     - Lønnstilskudd
   mottakere:


### PR DESCRIPTION
Due to how this is working, both Salesforce as an extern application and SaaS Proxy is needed.
Salesforce since it is the application that will ask for the token and be the authenticated application and "Produsent" towards the api. SaaS Proxy is need as it will transmit the request from Salesforce with the token provided to Salesforce.