### PR TITLE
Tilgang for yrkesskade

### DIFF
--- a/produsenter.yaml
+++ b/produsenter.yaml
@@ -148,7 +148,7 @@ yrkesskade-notifikasjon:
   accessPolicy:
     - dev-gcp:yrkesskade:yrkesskade-melding-mottak
   merkelapper:
-    - Innsendt skademelding
+    - Skademelding
   mottakere:
     - serviceCode: 5902
       serviceEdition: 1


### PR DESCRIPTION
Tilgang for yrkesskade

Har jeg tenkt rett at listen på venstre siden er merkelapp-taggen:
<img width="313" alt="bilde" src="https://github.com/navikt/arbeidsgiver-notifikasjon-produsenter/assets/329529/68852a63-0228-4459-bef4-677b829afeb7">
