### PR TITLE
Legg til ny merkelapp for inntektsmelding sykepenger

### DIFF
--- a/produsenter.yaml
+++ b/produsenter.yaml
@@ -110,6 +110,7 @@ im-notifikasjon:
     - prod-gcp:helsearbeidsgiver:im-notifikasjon
   merkelapper:
     - Inntektsmelding
+    - Inntektsmelding sykepenger
   mottakere:
     - serviceCode: 4936
       serviceEdition: 1


### PR DESCRIPTION
Fordi Team Foreldrepenger og Sykdom skal legge inn flere typer inntektsmelding-merkelapper, endrer vi inntektsmelding-merkelappen for sykepenger fra "Inntektsmelding" til "Inntektsmelding sykepenger". 

Steg en blir å legge den til, så fjerner vi den gamle merkelappen i senere PR, når vi ikke lenger bruker den.