### PR TITLE
lagt til tilgang for hag-admin-tool

### DIFF
--- a/produsenter.yaml
+++ b/produsenter.yaml
@@ -108,6 +108,8 @@ im-notifikasjon:
   accessPolicy:
     - dev-gcp:helsearbeidsgiver:im-notifikasjon
     - prod-gcp:helsearbeidsgiver:im-notifikasjon
+    - dev-gcp:helsearbeidsgiver:hag-admin
+    - prod-gcp:helsearbeidsgiver:hag-admin
   merkelapper:
     - Inntektsmelding
     - Inntektsmelding sykepenger


### PR DESCRIPTION
Ønsker tilgang til ny app for å manuelt lukke / administrere notifikasjoner der det er behov for dette 
(typisk er at en arbeidsgiver ber oss om å fjerne / lukke en notifikasjon)