### PR TITLE
bruker ikke inntektsmelding for tiltak

### DIFF
--- a/produsenter.yaml
+++ b/produsenter.yaml
@@ -44,8 +44,6 @@ arbeidsgiver-tiltak:
     - Inkluderingstilskudd
     - Varig tilrettelagt arbeid
   mottakere:
-    - serviceCode: 4936
-      serviceEdition: 1
     - serviceCode: 5516
       serviceEdition: 1
     - serviceCode: 5516


### PR DESCRIPTION
Vi bruker ikke inntektsmelding når vi oppretter saker, beskjeder og oppgaver på min side arbeidsgiver. Dermed kan denne fjernes fra våre mulige mottakere.


En liten sidenote for oss: Vi sender en type beskjeder som er refusjonsrelaterte, med teksten "Du kan nå søke om refusjon."
Denne beskjeden sendes med tilgangen som trengs for å åpne avtalen, f.eks. midlertidig lønnstilskudd - 5516:1 og merkelappen "Lønnstilskudd". Dette er jo kanskje litt dumt, da det ikke er tilgangen man trenger for å faktisk søke om refusjon. For øyeblikket er jo det inntektsmelding (4936:1), men etterhvert nav_tiltak_tiltaksrefsjon..