### PR TITLE
Legger til ressursId for fritakagp

### DIFF
--- a/produsenter.yaml
+++ b/produsenter.yaml
@@ -113,6 +113,7 @@ fritakagp:
   mottakere:
     - serviceCode: 4936
       serviceEdition: 1
+    - ressursId: nav_sykepenger_fritak-arbeidsgiverperiode
 
 im-notifikasjon:
   teamNavn: helsearbeidsgiver


### PR DESCRIPTION
Trenger å legge til ressursID nav_sykepenger_fritak-arbeidsgiverperiode på fritakagp da vi skal bytte til denne snart